### PR TITLE
Fix CMake example in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Then in your `CMakeLists.txt` file, include the following:
 
 ```cmake
 # ⤵️ Add to your CMake Project:
-add_subdirectories(external/crosswindow)
+add_subdirectory(external/crosswindow)
 
 # ❎ When creating your executable use CrossWindow's abstraction function:
 xwin_add_executable(


### PR DESCRIPTION
I didn't find the plural variant of `add_subdirectory` in CMake docs, only [a singular one](https://cmake.org/cmake/help/latest/command/add_subdirectory.html#:~:text=add_subdirectory).
The plural variant is probably a misspell if I haven't missed anything 😅 
By the way, the excellent example repository also contains only the singular variant.
https://github.com/alaingalvan/CrossWindow-Demos/blob/dd5f9d752ebe460f5daa10b3a8b63ff7a43a81c5/src/01-window-creation/CMakeLists.txt#L36