### PR TITLE
Remove border and title bar from get and set window size

### DIFF
--- a/src/CrossWindow/Win32/Win32Window.cpp
+++ b/src/CrossWindow/Win32/Win32Window.cpp
@@ -263,7 +263,19 @@ void Window::setPosition(unsigned x, unsigned y)
 
 void Window::setSize(unsigned width, unsigned height)
 {
-    SetWindowPos(hwnd, nullptr, -1, -1, width, height,
+    RECT rect, frame, border;
+    GetWindowRect(hwnd, &rect);
+    DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &frame, sizeof(RECT));
+
+    border.left = frame.left - rect.left;
+    border.top = frame.top - rect.top;
+    border.right = rect.right - frame.right;
+    border.bottom = rect.bottom - frame.bottom;
+
+    int titlebarHeight = (GetSystemMetrics(SM_CYFRAME) + GetSystemMetrics(SM_CYCAPTION) +
+        GetSystemMetrics(SM_CXPADDEDBORDER));
+
+    SetWindowPos(hwnd, nullptr, -1, -1, width + border.right + border.left, height + border.top + border.bottom + titlebarHeight,
                  SWP_NOMOVE | SWP_NOREDRAW);
 }
 
@@ -290,8 +302,9 @@ UVec2 Window::getPosition() const
 UVec2 Window::getWindowSize() const
 {
     RECT lpRect;
-    GetWindowRect(hwnd, &lpRect);
-    return UVec2(lpRect.right - lpRect.left, lpRect.bottom - lpRect.top);
+    DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &lpRect, sizeof(lpRect));
+    int titlebarHeight = (GetSystemMetrics(SM_CYFRAME) + GetSystemMetrics(SM_CYCAPTION) + GetSystemMetrics(SM_CXPADDEDBORDER));
+    return UVec2(lpRect.right - lpRect.left, lpRect.bottom - lpRect.top - titlebarHeight);
 }
 
 UVec2 Window::getCurrentDisplaySize() const


### PR DESCRIPTION
Get and set window size currently returns the whole window's size including the drag borders and titlebar, if that is the purpose of this function it could be handy that this could become a different function that explicity returns the drawable window size. This may not work with dpi scaling or other window's styles.