### PR TITLE
Fix MinGW dwmapi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set_property(
     STRINGS AUTO WIN32 UWP COCOA UIKIT XCB XLIB MIR WAYLAND ANDROID WASM NOOP
 )
 
-set(XWIN_OS AUTO CACHE STRING "Optional: Choose the OS to build for, defaults to AUTO, but can be WINDOWS, MACOS, LINUX, ANDROID, IOS, WASM.") 
+set(XWIN_OS AUTO CACHE STRING "Optional: Choose the OS to build for, defaults to AUTO, but can be WINDOWS, MACOS, LINUX, ANDROID, IOS, WASM.")
 set_property(
     CACHE
     XWIN_OS PROPERTY
@@ -117,6 +117,10 @@ file(GLOB_RECURSE MAIN_SOURCES RELATIVE
     ${CMAKE_HOME_DIRECTORY}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CrossWindow/Main/${XWIN_API_PATH}Main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CrossWindow/Main/${XWIN_API_PATH}Main.mm
+    if (MINGW)
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/CrossWindow/Main/mingw_loader.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/CrossWindow/Main/mingw_loader.h
+    endif()
 )
 
 set(XMAIN_SOURCES ${MAIN_SOURCES} CACHE STRING "Global Variable - The source files for the currently active protocol.")
@@ -186,6 +190,15 @@ add_library(
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/)
 
+# set _DEBUG on all compilers. Not only MSVC
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(${PROJECT_NAME} PUBLIC _DEBUG)
+endif()
+
+if (WIN32)
+    target_link_libraries(${PROJECT_NAME} PUBLIC dwmapi.lib uxtheme.lib)
+endif()
+
 # =============================================================
 
 # CrossWindow Dependencies
@@ -211,7 +224,7 @@ elseif(XWIN_API STREQUAL "UIKIT")
     find_library(MOBILECORESERVICES MobileCoreServices)
     find_library(CFNETWORK CFNetwork)
     find_library(SYSTEMCONFIGURATION SystemConfiguration)
-    
+
     target_link_libraries(
     ${PROJECT_NAME}
     ${UIKIT}

--- a/src/CrossWindow/Main/Win32Main.cpp
+++ b/src/CrossWindow/Main/Win32Main.cpp
@@ -2,6 +2,10 @@
 #include "Main.h"
 #include <stdio.h>
 
+#if defined(__MINGW32__)
+    #include "mingw_loader.h"
+#endif
+
 INT WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
                    _In_ LPSTR lpCmdLine, _In_ int nCmdShow)
 {
@@ -11,6 +15,10 @@ INT WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
     FILE* pCerr = nullptr;
     freopen_s(&pCout, "CONOUT$", "w+", stdout);
     freopen_s(&pCerr, "CONOUT$", "w+", stderr);
+#endif
+
+#if defined(__MINGW32__)
+    LoadDWMAPI loadDWMAPI;
 #endif
 
     // Setup command line arguments.

--- a/src/CrossWindow/Main/mingw_loader.cpp
+++ b/src/CrossWindow/Main/mingw_loader.cpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "mingw_loader.h"
+#include <stdio.h>
+
+#if defined(__MINGW32__)
+
+DwmDefWindowProcFunc                    pDwmDefWindowProc                   = nullptr;
+DwmEnableBlurBehindWindowFunc           pDwmEnableBlurBehindWindow          = nullptr;
+DwmEnableCompositionFunc                pDwmEnableComposition               = nullptr;
+DwmEnableMMCSSFunc                      pDwmEnableMMCSS                     = nullptr;
+DwmExtendFrameIntoClientAreaFunc        pDwmExtendFrameIntoClientArea       = nullptr;
+DwmGetColorizationColorFunc             pDwmGetColorizationColor            = nullptr;
+DwmGetCompositionTimingInfoFunc         pDwmGetCompositionTimingInfo        = nullptr;
+DwmGetWindowAttributeFunc               pDwmGetWindowAttribute              = nullptr;
+DwmIsCompositionEnabledFunc             pDwmIsCompositionEnabled            = nullptr;
+DwmModifyPreviousDxFrameDurationFunc    pDwmModifyPreviousDxFrameDuration   = nullptr;
+DwmQueryThumbnailSourceSizeFunc         pDwmQueryThumbnailSourceSize        = nullptr;
+DwmRegisterThumbnailFunc                pDwmRegisterThumbnail               = nullptr;
+DwmSetDxFrameDurationFunc               pDwmSetDxFrameDuration              = nullptr;
+DwmSetPresentParametersFunc             pDwmSetPresentParameters            = nullptr;
+DwmSetWindowAttributeFunc               pDwmSetWindowAttribute              = nullptr;
+DwmUnregisterThumbnailFunc              pDwmUnregisterThumbnail             = nullptr;
+DwmUpdateThumbnailPropertiesFunc        pDwmUpdateThumbnailProperties       = nullptr;
+DwmAttachMilContentFunc                 pDwmAttachMilContent                = nullptr;
+DwmDetachMilContentFunc                 pDwmDetachMilContent                = nullptr;
+DwmFlushFunc                            pDwmFlush                           = nullptr;
+DwmGetGraphicsStreamTransformHintFunc   pDwmGetGraphicsStreamTransformHint  = nullptr;
+DwmGetGraphicsStreamClientFunc          pDwmGetGraphicsStreamClient         = nullptr;
+DwmGetTransportAttributesFunc           pDwmGetTransportAttributes          = nullptr;
+DwmTransitionOwnedWindowFunc            pDwmTransitionOwnedWindow           = nullptr;
+
+// Windows 7
+#if _WIN32_WINNT >= 0x0601
+DwmSetIconicThumbnailFunc               pDwmSetIconicThumbnail              = nullptr;
+DwmSetIconicLivePreviewBitmapFunc       pDwmSetIconicLivePreviewBitmap      = nullptr;
+DwmInvalidateIconicBitmapsFunc          pDwmInvalidateIconicBitmaps         = nullptr;
+
+#endif
+
+LoadDWMAPI::LoadDWMAPI() {
+    hDwmapi = LoadLibrary(TEXT("dwmapi.dll"));
+    if (hDwmapi != NULL) {
+        fprintf(stdout, "dwmapi loaded\n");
+        pDwmDefWindowProc                  = (DwmDefWindowProcFunc)                  GetProcAddress(hDwmapi, "DwmDefWindowProc");
+        pDwmEnableBlurBehindWindow         = (DwmEnableBlurBehindWindowFunc)         GetProcAddress(hDwmapi, "DwmEnableBlurBehindWindow");
+        pDwmEnableComposition              = (DwmEnableCompositionFunc)              GetProcAddress(hDwmapi, "DwmEnableComposition");
+        pDwmEnableMMCSS                    = (DwmEnableMMCSSFunc)                    GetProcAddress(hDwmapi, "DwmEnableMMCSS");
+        pDwmExtendFrameIntoClientArea      = (DwmExtendFrameIntoClientAreaFunc)      GetProcAddress(hDwmapi, "DwmExtendFrameIntoClientArea");
+        pDwmGetColorizationColor           = (DwmGetColorizationColorFunc)           GetProcAddress(hDwmapi, "DwmGetColorizationColor");
+        pDwmGetCompositionTimingInfo       = (DwmGetCompositionTimingInfoFunc)       GetProcAddress(hDwmapi, "DwmGetCompositionTimingInfo");
+        pDwmGetWindowAttribute             = (DwmGetWindowAttributeFunc)             GetProcAddress(hDwmapi, "DwmGetWindowAttribute");
+        pDwmIsCompositionEnabled           = (DwmIsCompositionEnabledFunc)           GetProcAddress(hDwmapi, "DwmIsCompositionEnabled");
+        pDwmModifyPreviousDxFrameDuration  = (DwmModifyPreviousDxFrameDurationFunc)  GetProcAddress(hDwmapi, "DwmModifyPreviousDxFrameDuration");
+        pDwmQueryThumbnailSourceSize       = (DwmQueryThumbnailSourceSizeFunc)       GetProcAddress(hDwmapi, "DwmQueryThumbnailSourceSize");
+        pDwmRegisterThumbnail              = (DwmRegisterThumbnailFunc)              GetProcAddress(hDwmapi, "DwmRegisterThumbnail");
+        pDwmSetDxFrameDuration             = (DwmSetDxFrameDurationFunc)             GetProcAddress(hDwmapi, "DwmSetDxFrameDuration");
+        pDwmSetPresentParameters           = (DwmSetPresentParametersFunc)           GetProcAddress(hDwmapi, "DwmSetPresentParameters");
+        pDwmSetWindowAttribute             = (DwmSetWindowAttributeFunc)             GetProcAddress(hDwmapi, "DwmSetWindowAttribute");
+        pDwmUnregisterThumbnail            = (DwmUnregisterThumbnailFunc)            GetProcAddress(hDwmapi, "DwmUnregisterThumbnail");
+        pDwmUpdateThumbnailProperties      = (DwmUpdateThumbnailPropertiesFunc)      GetProcAddress(hDwmapi, "DwmUpdateThumbnailProperties");
+        pDwmAttachMilContent               = (DwmAttachMilContentFunc)               GetProcAddress(hDwmapi, "DwmAttachMilContent");
+        pDwmDetachMilContent               = (DwmDetachMilContentFunc)               GetProcAddress(hDwmapi, "DwmDetachMilContent");
+        pDwmFlush                          = (DwmFlushFunc)                          GetProcAddress(hDwmapi, "DwmFlush");
+        pDwmGetGraphicsStreamTransformHint = (DwmGetGraphicsStreamTransformHintFunc) GetProcAddress(hDwmapi, "DwmGetGraphicsStreamTransformHint");
+        pDwmGetGraphicsStreamClient        = (DwmGetGraphicsStreamClientFunc)        GetProcAddress(hDwmapi, "DwmGetGraphicsStreamClient");
+        pDwmGetTransportAttributes         = (DwmGetTransportAttributesFunc)         GetProcAddress(hDwmapi, "DwmGetTransportAttributes");
+        pDwmTransitionOwnedWindow          = (DwmTransitionOwnedWindowFunc)          GetProcAddress(hDwmapi, "DwmTransitionOwnedWindow");
+
+// Windows 7
+#if _WIN32_WINNT >= 0x0601
+        pDwmSetIconicThumbnail             = (DwmSetIconicThumbnailFunc)             GetProcAddress(hDwmapi, "DwmSetIconicThumbnail");
+        pDwmSetIconicLivePreviewBitmap     = (DwmSetIconicLivePreviewBitmapFunc)     GetProcAddress(hDwmapi, "DwmSetIconicLivePreviewBitmap");
+        pDwmInvalidateIconicBitmaps        = (DwmInvalidateIconicBitmapsFunc)        GetProcAddress(hDwmapi, "DwmInvalidateIconicBitmaps");
+#endif
+
+    }
+    else {
+        fprintf(stderr, "dwmapi NOT loaded\n");
+    }
+}
+
+LoadDWMAPI::~LoadDWMAPI() {
+    FreeLibrary(hDwmapi);
+}
+
+#endif  // __MINGW32__

--- a/src/CrossWindow/Main/mingw_loader.h
+++ b/src/CrossWindow/Main/mingw_loader.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <Windows.h>
+#include <dwmapi.h>
+
+#if defined(__MINGW32__)
+    typedef WINBOOL (WINAPI *DwmDefWindowProcFunc)(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, LRESULT *plResult);
+    typedef HRESULT (WINAPI *DwmEnableBlurBehindWindowFunc)(HWND hWnd, const DWM_BLURBEHIND *pBlurBehind);
+    typedef HRESULT (WINAPI *DwmEnableCompositionFunc)(UINT uCompositionAction);
+    typedef HRESULT (WINAPI *DwmEnableMMCSSFunc)(WINBOOL fEnableMMCSS);
+    typedef HRESULT (WINAPI *DwmExtendFrameIntoClientAreaFunc)(HWND hWnd, const MARGINS *pMarInset);
+    typedef HRESULT (WINAPI *DwmGetColorizationColorFunc)(DWORD *pcrColorization, WINBOOL *pfOpaqueBlend);
+    typedef HRESULT (WINAPI *DwmGetCompositionTimingInfoFunc)(HWND hwnd, DWM_TIMING_INFO* pTimingInfo);
+    typedef HRESULT (WINAPI *DwmGetWindowAttributeFunc)(HWND hwnd, DWORD dwAttribute, PVOID pvAttribute, DWORD cbAttribute);
+    typedef HRESULT (WINAPI *DwmIsCompositionEnabledFunc)(BOOL* pfEnabled);
+    typedef HRESULT (WINAPI *DwmModifyPreviousDxFrameDurationFunc)(HWND hwnd, INT cRefreshes, BOOL fRelative);
+    typedef HRESULT (WINAPI *DwmQueryThumbnailSourceSizeFunc)(HTHUMBNAIL hThumbnail, PSIZE pSize);
+    typedef HRESULT (WINAPI *DwmRegisterThumbnailFunc)(HWND hwndDestination, HWND hwndSource, PHTHUMBNAIL phThumbnailId);
+    typedef HRESULT (WINAPI *DwmSetDxFrameDurationFunc)(HWND hwnd, INT cRefreshes);
+    typedef HRESULT (WINAPI *DwmSetPresentParametersFunc)(HWND hwnd, DWM_PRESENT_PARAMETERS *pPresentParams);
+    typedef HRESULT (WINAPI *DwmSetWindowAttributeFunc)(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute);
+    typedef HRESULT (WINAPI *DwmUnregisterThumbnailFunc)(HTHUMBNAIL hThumbnailId);
+    typedef HRESULT (WINAPI *DwmUpdateThumbnailPropertiesFunc)(HTHUMBNAIL hThumbnailId, const DWM_THUMBNAIL_PROPERTIES *ptnProperties);
+    typedef HRESULT (WINAPI *DwmAttachMilContentFunc)(HWND hwnd);
+    typedef HRESULT (WINAPI *DwmDetachMilContentFunc)(HWND hwnd);
+    typedef HRESULT (WINAPI *DwmFlushFunc)(void);
+    typedef HRESULT (WINAPI *DwmGetGraphicsStreamTransformHintFunc)(UINT uIndex, MilMatrix3x2D *pTransform);
+    typedef HRESULT (WINAPI *DwmGetGraphicsStreamClientFunc)(UINT uIndex, UUID *pClientUuid);
+    typedef HRESULT (WINAPI *DwmGetTransportAttributesFunc)(BOOL *pfIsRemoting, BOOL *pfIsConnected, DWORD *pDwGeneration);
+    typedef HRESULT (WINAPI *DwmTransitionOwnedWindowFunc)(HWND hwnd, DWMTRANSITION_OWNEDWINDOW_TARGET target);
+
+// Windows 7
+#if _WIN32_WINNT >= 0x0601
+    typedef HRESULT (WINAPI *DwmSetIconicThumbnailFunc)(HWND hwnd, HBITMAP hbmp, DWORD dwSITFlags);
+    typedef HRESULT (WINAPI *DwmSetIconicLivePreviewBitmapFunc)(HWND hwnd, HBITMAP hbmp, POINT *pptClient, DWORD dwSITFlags);
+    typedef HRESULT (WINAPI *DwmInvalidateIconicBitmapsFunc)(HWND hwnd);
+#endif
+
+    extern "C" DwmDefWindowProcFunc                    pDwmDefWindowProc;
+    extern "C" DwmEnableBlurBehindWindowFunc           pDwmEnableBlurBehindWindow;
+    extern "C" DwmEnableCompositionFunc                pDwmEnableComposition;
+    extern "C" DwmEnableMMCSSFunc                      pDwmEnableMMCSS;
+    extern "C" DwmExtendFrameIntoClientAreaFunc        pDwmExtendFrameIntoClientArea;
+    extern "C" DwmGetColorizationColorFunc             pDwmGetColorizationColor;
+    extern "C" DwmGetCompositionTimingInfoFunc         pDwmGetCompositionTimingInfo;
+    extern "C" DwmGetWindowAttributeFunc               pDwmGetWindowAttribute;
+    extern "C" DwmIsCompositionEnabledFunc             pDwmIsCompositionEnabled;
+    extern "C" DwmModifyPreviousDxFrameDurationFunc    pDwmModifyPreviousDxFrameDuration;
+    extern "C" DwmQueryThumbnailSourceSizeFunc         pDwmQueryThumbnailSourceSize;
+    extern "C" DwmRegisterThumbnailFunc                pDwmRegisterThumbnail;
+    extern "C" DwmSetDxFrameDurationFunc               pDwmSetDxFrameDuration;
+    extern "C" DwmSetPresentParametersFunc             pDwmSetPresentParameters;
+    extern "C" DwmSetWindowAttributeFunc               pDwmSetWindowAttribute;
+    extern "C" DwmUnregisterThumbnailFunc              pDwmUnregisterThumbnail;
+    extern "C" DwmUpdateThumbnailPropertiesFunc        pDwmUpdateThumbnailProperties;
+    extern "C" DwmAttachMilContentFunc                 pDwmAttachMilContent;
+    extern "C" DwmDetachMilContentFunc                 pDwmDetachMilContent;
+    extern "C" DwmFlushFunc                            pDwmFlush;
+    extern "C" DwmGetGraphicsStreamTransformHintFunc   pDwmGetGraphicsStreamTransformHint;
+    extern "C" DwmGetGraphicsStreamClientFunc          pDwmGetGraphicsStreamClient;
+    extern "C" DwmGetTransportAttributesFunc           pDwmGetTransportAttributes;
+    extern "C" DwmTransitionOwnedWindowFunc            pDwmTransitionOwnedWindow;
+
+// Windows 7
+#if _WIN32_WINNT >= 0x0601
+    extern "C" DwmSetIconicThumbnailFunc               pDwmSetIconicThumbnail;
+    extern "C" DwmSetIconicLivePreviewBitmapFunc       pDwmSetIconicLivePreviewBitmap;
+    extern "C" DwmInvalidateIconicBitmapsFunc          pDwmInvalidateIconicBitmaps;
+#endif
+
+    struct LoadDWMAPI {
+        LoadDWMAPI();
+        ~LoadDWMAPI();
+
+        HMODULE hDwmapi = nullptr;
+    };
+
+    #define DwmDefWindowProc                        pDwmDefWindowProc
+    #define DwmEnableBlurBehindWindow               pDwmEnableBlurBehindWindow
+    #define DwmEnableComposition                    pDwmEnableComposition
+    #define DwmEnableMMCSS                          pDwmEnableMMCSS
+    #define DwmExtendFrameIntoClientArea            pDwmExtendFrameIntoClientArea
+    #define DwmGetColorizationColor                 pDwmGetColorizationColor
+    #define DwmGetCompositionTimingInfo             pDwmGetCompositionTimingInfo
+    #define DwmGetWindowAttribute                   pDwmGetWindowAttribute
+    #define DwmIsCompositionEnabled                 pDwmIsCompositionEnabled
+    #define DwmModifyPreviousDxFrameDuration        pDwmModifyPreviousDxFrameDuration
+    #define DwmQueryThumbnailSourceSize             pDwmQueryThumbnailSourceSize
+    #define DwmRegisterThumbnail                    pDwmRegisterThumbnail
+    #define DwmSetDxFrameDuration                   pDwmSetDxFrameDuration
+    #define DwmSetPresentParameters                 pDwmSetPresentParameters
+    #define DwmSetWindowAttribute                   pDwmSetWindowAttribute
+    #define DwmUnregisterThumbnail                  pDwmUnregisterThumbnail
+    #define DwmUpdateThumbnailProperties            pDwmUpdateThumbnailProperties
+    #define DwmAttachMilContent                     pDwmAttachMilContent
+    #define DwmDetachMilContent                     pDwmDetachMilContent
+    #define DwmFlush                                pDwmFlush
+    #define DwmGetGraphicsStreamTransformHint       pDwmGetGraphicsStreamTransformHint
+    #define DwmGetGraphicsStreamClient              pDwmGetGraphicsStreamClient
+    #define DwmGetTransportAttributes               pDwmGetTransportAttributes
+    #define DwmTransitionOwnedWindow                pDwmTransitionOwnedWindow
+
+// Windows 7
+#if _WIN32_WINNT >= 0x0601
+    #define DwmSetIconicThumbnail                   pDwmSetIconicThumbnail
+    #define DwmSetIconicLivePreviewBitmap           pDwmSetIconicLivePreviewBitmap
+    #define DwmInvalidateIconicBitmaps              pDwmInvalidateIconicBitmaps
+#endif
+
+#endif  // __MINGW32__

--- a/src/CrossWindow/Win32/Win32Window.cpp
+++ b/src/CrossWindow/Win32/Win32Window.cpp
@@ -1,10 +1,10 @@
 #include "Win32Window.h"
-
-#include "Shobjidl.h"
-#include "dwmapi.h"
+#include "../Main/mingw_loader.h"
+#include <Shobjidl.h>
+#include <dwmapi.h>
 #include <windowsx.h>
-#pragma comment(lib, "dwmapi.lib")
-#pragma comment(lib, "uxtheme.lib")
+//#pragma comment(lib, "dwmapi.lib")
+//#pragma comment(lib, "uxtheme.lib")
 
 enum Style : DWORD
 {


### PR DESCRIPTION
For some reason, dwmapi is not available on MinGW. 
With this patch, we can use this compiler for building