### PR TITLE
Mac: Added missing close, focus and resize events

### DIFF
--- a/src/CrossWindow/Cocoa/CocoaEventQueue.mm
+++ b/src/CrossWindow/Cocoa/CocoaEventQueue.mm
@@ -107,7 +107,23 @@ void EventQueue::update()
                     break;
                 case NSEventTypeScrollWheel:
                     [nsEvent deltaY];
-                    
+                    break;
+
+                case NSEventTypeApplicationDefined:
+                    switch((EventType) nsEvent.subtype) {
+                        case EventType::Close: {
+                            curEvent = xwin::Event(EventType::Close);
+                        } break;
+                        case EventType::Resize: {
+                            curEvent = xwin::Event(xwin::ResizeData(nsEvent.data1, nsEvent.data2, true));
+                        } break;
+                        case EventType::Focus: {
+                            curEvent = xwin::Event(xwin::FocusData(nsEvent.data1 ? true : false));
+                        } break;
+                        default: {
+
+                        } break;
+                    }
                     break;
                 default:
                     break;

--- a/src/CrossWindow/Cocoa/CocoaWindow.h
+++ b/src/CrossWindow/Cocoa/CocoaWindow.h
@@ -54,6 +54,9 @@ class Window
     // XWinWindow*
     void* window;
 
+    // XWinWindowDelegate*
+    void* windowDelegate;
+
     // XWinView*
     void* view;
 


### PR DESCRIPTION
Thanks for the work to create this! Unfortunately it wouldn't fit my needs without some of these key events on Mac, so I've done my best to add them!

I added an `NSWindowDelegate` to the `NSWindow` to get more information about what's happening with the window (looking at the `NSWindowDelegate` API, there's more that can now be done here I'm sure). It emits `NSEvents` of type _ApplicationDefined_ (as recommended by docs) back to the `NSApplication` to be picked up in your existing `EventQueue`.

I don't have much Objective-C experience so apologies in advance! I've tried to mirror the existing implementation/style as much as possible.